### PR TITLE
PauseMenu Fixes

### DIFF
--- a/deathmatch/Game/Game.tscn
+++ b/deathmatch/Game/Game.tscn
@@ -111,10 +111,9 @@ layout_mode = 2
 [node name="Card24" parent="PlayArea/CardField/Card Area" instance=ExtResource("3_iv3md")]
 layout_mode = 2
 
-[node name="CanvasLayer" type="CanvasLayer" parent="PlayArea"]
+[node name="PauseLayer" type="CanvasLayer" parent="PlayArea"]
 
-[node name="PauseMenu" parent="PlayArea/CanvasLayer" instance=ExtResource("1_hqwdr")]
+[node name="PauseMenu" parent="PlayArea/PauseLayer" instance=ExtResource("1_hqwdr")]
 size_flags_horizontal = 4
 size_flags_vertical = 4
 mouse_filter = 2
-metadata/_edit_use_anchors_ = true

--- a/deathmatch/Menus/PauseMenu.tscn
+++ b/deathmatch/Menus/PauseMenu.tscn
@@ -12,6 +12,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
 script = ExtResource("1_qnjt8")
 main_menu = ExtResource("2_hnfxo")
 settings_menu = NodePath("SettingsMenu")
@@ -32,14 +34,14 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = 56.0
-offset_bottom = 123.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="CenterContainer" type="CenterContainer" parent="PauseMenuControl/PanelContainer"]
 process_mode = 3
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
 [node name="VBoxContainer" type="VBoxContainer" parent="PauseMenuControl/PanelContainer/CenterContainer"]
 process_mode = 3

--- a/deathmatch/Menus/pause_menu.gd
+++ b/deathmatch/Menus/pause_menu.gd
@@ -10,8 +10,10 @@ func _ready() -> void:
 
 func _input(_event: InputEvent) -> void:
 	if (Input.is_action_just_pressed("Pause")):
-		print("Pausing")
-		toggle_pause()
+		if (get_tree().paused && settings_menu.visible):
+			show_hide()
+		else:
+			toggle_pause()
 
 func toggle_pause() -> void:
 	get_tree().paused = !get_tree().paused


### PR DESCRIPTION
Fixes #4 

I pushed some container Sizing buttons and somehow magically fucking centered the Pause Menu. Look I used a CenterContainer anchored to the whole screen... IDFK anymore.

Added robust logic to _input() to detect if game is paused and settings menu is open to correctly toggle the settings menu visibility & pause menu visibility. 